### PR TITLE
Add medicine support to fridges

### DIFF
--- a/Defs/ThingDefs/Buildings_Refrigerated_StorageRacks.xml
+++ b/Defs/ThingDefs/Buildings_Refrigerated_StorageRacks.xml
@@ -37,7 +37,8 @@
           <categories>
             <li>Foods</li>
             <li>AnimalProductRaw</li>
-            <li>PlantMatter</li>            
+            <li>PlantMatter</li>
+			<li>Medicine</li>
           </categories>
           <thingDefs>
             <li>Beer</li>


### PR DESCRIPTION
Fixes #1, add `Medicine` category support.